### PR TITLE
Fix authentication and database creation

### DIFF
--- a/src/Aspire.Hosting/MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBBuilderExtensions.cs
@@ -68,6 +68,8 @@ public static class MongoDBBuilderExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{MongoDBDatabaseResource}"/>.</returns>
     public static IResourceBuilder<MongoDBDatabaseResource> AddDatabase(this IResourceBuilder<MongoDBContainerResource> builder, string name)
     {
+        builder.WithEnvironment("MONGO_INITDB_DATABASE", name);
+
         var mongoDBDatabase = new MongoDBDatabaseResource(name, builder.Resource);
 
         return builder.ApplicationBuilder

--- a/src/Aspire.Hosting/MongoDB/MongoDBConnectionStringBuilder.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBConnectionStringBuilder.cs
@@ -6,6 +6,7 @@ namespace Aspire.Hosting.MongoDB;
 internal class MongoDBConnectionStringBuilder
 {
     private const string Scheme = "mongodb";
+    private const string AuthenticationDatabase = "admin";
 
     private string? _server;
     private int _port;
@@ -54,7 +55,8 @@ internal class MongoDBConnectionStringBuilder
             Host = _server,
             Port = _port,
             UserName = _userName,
-            Password = _password
+            Password = _password,
+            Path = AuthenticationDatabase
         };
 
         return builder.ToString();

--- a/src/Aspire.Hosting/MongoDB/MongoDBDatabaseResource.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBDatabaseResource.cs
@@ -21,9 +21,7 @@ public class MongoDBDatabaseResource(string name, MongoDBContainerResource mongo
     {
         if (Parent.GetConnectionString() is { } connectionString)
         {
-            return connectionString.EndsWith('/') ?
-                $"{connectionString}{Name}" :
-                $"{connectionString}/{Name}";
+            return connectionString;
         }
 
         throw new DistributedApplicationException("Parent resource connection string was null.");

--- a/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
+++ b/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
@@ -94,6 +94,6 @@ public class AddMongoDBTests
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<MongoDBDatabaseResource>());
         var connectionString = connectionStringResource.GetConnectionString();
 
-        Assert.Equal("mongodb://root:password@localhost:27017/mydatabase", connectionString);
+        Assert.Equal("mongodb://root:password@localhost:27017/admin", connectionString);
     }
 }

--- a/tests/Aspire.Hosting.Tests/MongoDB/MongoDBContainerResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/MongoDB/MongoDBContainerResourceTests.cs
@@ -10,14 +10,14 @@ namespace Aspire.Hosting.Tests.MongoDB;
 public class MongoDBContainerResourceTests
 {
     [Theory]
-    [InlineData("password", "mongodb://root:password@myserver:1000/")]
-    [InlineData("@abc!$", "mongodb://root:%40abc!$@myserver:1000/")]
-    [InlineData("mypasswordwitha\"inthemiddle", "mongodb://root:mypasswordwitha\"inthemiddle@myserver:1000/")]
-    [InlineData("mypasswordwitha\"attheend\"", "mongodb://root:mypasswordwitha\"attheend\"@myserver:1000/")]
-    [InlineData("\"mypasswordwitha\"atthestart", "mongodb://root:\"mypasswordwitha\"atthestart@myserver:1000/")]
-    [InlineData("mypasswordwitha'inthemiddle", "mongodb://root:mypasswordwitha'inthemiddle@myserver:1000/")]
-    [InlineData("mypasswordwitha'attheend'", "mongodb://root:mypasswordwitha'attheend'@myserver:1000/")]
-    [InlineData("'mypasswordwitha'atthestart", "mongodb://root:'mypasswordwitha'atthestart@myserver:1000/")]
+    [InlineData("password", "mongodb://root:password@myserver:1000/admin")]
+    [InlineData("@abc!$", "mongodb://root:%40abc!$@myserver:1000/admin")]
+    [InlineData("mypasswordwitha\"inthemiddle", "mongodb://root:mypasswordwitha\"inthemiddle@myserver:1000/admin")]
+    [InlineData("mypasswordwitha\"attheend\"", "mongodb://root:mypasswordwitha\"attheend\"@myserver:1000/admin")]
+    [InlineData("\"mypasswordwitha\"atthestart", "mongodb://root:\"mypasswordwitha\"atthestart@myserver:1000/admin")]
+    [InlineData("mypasswordwitha'inthemiddle", "mongodb://root:mypasswordwitha'inthemiddle@myserver:1000/admin")]
+    [InlineData("mypasswordwitha'attheend'", "mongodb://root:mypasswordwitha'attheend'@myserver:1000/admin")]
+    [InlineData("'mypasswordwitha'atthestart", "mongodb://root:'mypasswordwitha'atthestart@myserver:1000/admin")]
     public void TestSpecialCharactersAndEscapeForPassword(string password, string expectedConnectionString)
     {
         var connectionString = new MongoDBConnectionStringBuilder()


### PR DESCRIPTION
With the docker image, authentication only works when the connection string uses the `admin` database, so using it for the connection string.

The database can be created automatically using `MONGO_INITDB_DATABASE` on the container.

Without these two changes only the `admin` database can be used in `AddDatabase(string name)`.

c.f. https://hub.docker.com/_/mongo/